### PR TITLE
Imports Sempaphore, adds groups/members, and adds NFT editions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/solady"]
 	path = lib/solady
 	url = https://github.com/vectorized/solady
+[submodule "lib/semaphore"]
+	path = lib/semaphore
+	url = https://github.com/semaphore-protocol/semaphore

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,1 +1,2 @@
 solady/=lib/solady/src/
+semaphore/=lib/semaphore/packages/contracts/contracts/

--- a/src/IVerifier.sol
+++ b/src/IVerifier.sol
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
-
-interface IVerifier {}

--- a/src/JubjubPoap.sol
+++ b/src/JubjubPoap.sol
@@ -7,7 +7,7 @@ import {LibBitmap} from "solady/utils/LibBitmap.sol";
 import {LibString} from "solady/utils/LibString.sol";
 import {ISemaphore} from "semaphore/interfaces/ISemaphore.sol";
 
-contract JubjubPoap is ERC721, Ownable {
+contract JubjubPoap is ERC721 {
     using LibBitmap for LibBitmap.Bitmap;
     using LibString for uint256;
 
@@ -25,7 +25,7 @@ contract JubjubPoap is ERC721, Ownable {
     uint8 public currentEdition;
     uint96 public nextTokenId;
 
-    /// @notice the public key of the card managing this group
+    /// @notice 
     address public signer;
     /// @notice semaphore group id this contract is managing
     address public groupId;
@@ -40,23 +40,35 @@ contract JubjubPoap is ERC721, Ownable {
     error NotAdmin();
     error AddMemberFailed();
 
-    event SignerSet(address signer);
-
     constructor(ISemaphore semaphore_) {
         semaphore = semaphore_;
     }
 
-    function intialize(address owner_, uint256 groupId_, string calldata name_, string calldata symbol_, string calldata tokenURI_, address signer_)
+    /**
+     @notice -
+     @param signer_ - the public key of the card managing this group
+     @param groupID_ - semaphore group id for ACL and nullifiers
+     @param name_ - NFT token name
+     @param symbol_ - NFT token symbol
+     @param tokenURI_ - default NFT art to display
+    */
+    function intialize(address signer_, uint256 groupId_, string calldata name_, string calldata symbol_, string calldata tokenURI_)
         external
     {
         if (bytes(_name).length == 0) revert AlreadyInitialized();
         if (bytes(name_).length == 0) revert InvalidNameLength();
-        _initializeOwner(signer_);
         _name = name_;
         _symbol = symbol_;
         _defaultTokenURI = tokenURI_;
+
+        signer = signer_;
         groupId = groupId_;
-        semaphore.createGroup(groupId_, 0 /* TODO: merkleTreeDepth */, signer);
+        semaphore.createGroup(groupId_, 0 /* TODO: merkleTreeDepth */, signer_);
+    }
+
+    modifier onlyOwner() {
+        if (!msg.sender == signer) revert NotAdmin();
+        _;
     }
 
     function name() public view override returns (string memory) {

--- a/src/JubjubPoap.sol
+++ b/src/JubjubPoap.sol
@@ -5,7 +5,7 @@ import {ERC721} from "solady/tokens/ERC721.sol";
 import {Ownable} from "solady/auth/Ownable.sol";
 import {LibBitmap} from "solady/utils/LibBitmap.sol";
 import {LibString} from "solady/utils/LibString.sol";
-import {IVerifier} from "./IVerifier.sol";
+import {ISemaphore} from "semaphore/interfaces/ISemaphore.sol";
 
 contract JubjubPoap is ERC721, Ownable {
     using LibBitmap for LibBitmap.Bitmap;
@@ -13,41 +13,46 @@ contract JubjubPoap is ERC721, Ownable {
 
     string internal _name;
     string internal _symbol;
-    string internal _tokenURI;
+    string internal _defaultTokenURI;
 
-    mapping(bytes32 => bool) public nullifierUsed;
+    // not needed. handled in semaphore.verifyProof already - https://github.com/semaphore-protocol/semaphore/blob/715b1f8ac56d0c7e33aca96b97cc9c2be5aa47bc/packages/contracts/contracts/Semaphore.sol#L181
+    // mapping(bytes32 => bool) public nullifierUsed;
+    mapping(uint256 => string) public tokenUriOverrides;
     uint96 public nextTokenId;
-    address public signer;
 
-    IVerifier public immutable verifier;
+    /// @notice the public key of the card managing group
+    address public signer;
+    /// @notice semaphore group id this contract is managing
+    address public groupId;
+    /// @notice Sempahore singleton group manager contract to control access to this group
+    ISemaphore public immutable semaphore;
 
     error AlreadyInitialized();
     error InvalidNameLength();
     error NonceReused();
     error NullifierAlreadyUsed();
     error VerificationFailed();
+    error NotAdmin();
+    error AddMemberFailed();
 
     event SignerSet(address signer);
 
-    constructor(IVerifier verifier_) {
-        verifier = verifier_;
+    constructor(IVerifier semaphore_) {
+        semaphore = semaphore_;
     }
 
-    function intialize(address owner_, string calldata name_, string calldata symbol_, string calldata tokenURI_, address initialSigner)
+    function intialize(address owner_, uint256 groupId_, string calldata name_, string calldata symbol_, string calldata tokenURI_, address signer_)
         external
     {
         if (bytes(_name).length == 0) revert AlreadyInitialized();
         if (bytes(name_).length == 0) revert InvalidNameLength();
-        _initializeOwner(owner_);
+        _initializeOwner(signer_);
         _name = name_;
         _symbol = symbol_;
-        _tokenURI = tokenURI_;
-        _setSigner(initialSigner);
+        _defaultTokenURI = tokenURI_;
+        groupId = groupId_;
+        semaphore.createGroup(groupId_, 0 /* TODO: merkleTreeDepth */, signer);
     }
-
-    function setSigner(address newSigner) external onlyOwner() {
-        _setSigner(newSigner);
-    } 
 
     function name() public view override returns (string memory) {
         return _name;
@@ -58,17 +63,49 @@ contract JubjubPoap is ERC721, Ownable {
     }
 
     function tokenURI(uint256 id) public view override returns (string memory) {
-        return string.concat(_tokenURI, id.toString());
+        return string.concat(_defaultTokenURI, id.toString());
     }
 
-    function mint(bytes32 nullifier, bytes memory signature, bytes memory proof) external {
-        if (nullifierUsed[nullifier]) revert NullifierAlreadyUsed();
-        address signer_ = signer;
-        if (!verifier.verify(signer_, nullifier, proof)) revert VerificationFailed();
+    function setTokenURI(uint256 id, string calldata tokenURI_) onlyOwner() external {
+        tokenUriOverrides[id] = tokenURI_;
     }
 
-    function _setSigner(address newSigner) internal {
-        signer = newSigner;
-        emit SignerSet(newSigner);
+    function mint(bytes32 nullifierHash, address recipient, uint266 idCommitment, bytes memory signature, uint256[8] calldata proof) external {
+        // address signer_ = signer;
+        // if (!semaphore.verify(signer_, nullifierHash, proof)) revert VerificationFailed();
+
+        if (!semaphore.verifyProof(
+            groupId,
+            0, /* merkel tree root */
+            uint256(recipient), /* signal aka recipient address */
+            nullifierHash,
+            groupId, /* external nullifier */
+            proof
+        )) revert VerificationFailed();
+
+        try(semaphore.addMember(groupId_, idCommitment)) {
+            _mint(recipient, nextTokenId);
+            unchecked {
+                ++nextTokenId;
+            }
+        } catch(bytes memory) {
+            revert AddMemberFailed();
+        }
+        
     }
+
+    /**
+     * functions to delegate functionality to Semaphore instead of contract specific ACL
+     */
+
+    // function updateAdmin(address newAdmin) internal onlyOwner() {
+    //     semaphore.updateGroupAdmin(groupId, newAdmin);
+    // }
+    
+    /// @notice override default check to look at semaphore group admin instead of local contract data
+    // function _checkOwner() internal view override virtual returns(bool) {
+    //     return semaphore.groups(groupId).admin == msg.sender;
+    // }
+
+
 }


### PR DESCRIPTION
- ran `forge install  semaphore-protocol/contracts`
- import ISemaphore or IVerifier (depending on our use) for our use
- setups Semaphore group on deploy
- adds minters as members to group
- Allows owner to setup "editions" where specific  signature nonce ranges are associated with unique images
- default NFT image if no edition specific art setup
- remove OZ Ownable because we want only the card holder to be able to manage contract which means no transfer/revoke so mostly bloat code.
